### PR TITLE
fix defaultTimes in non-exhaustive mode

### DIFF
--- a/examples/Aegisub/Inspector.moon
+++ b/examples/Aegisub/Inspector.moon
@@ -141,16 +141,12 @@ defaultTimes = ( lines ) ->
 
 	for line in *lines
 		with line
-			if (true == .assi_exhaustive) and hasFrames
-				for frame = ffms( .start_time ), ffms( .end_time ) - 1
+			if hasFrames
+				for frame = ffms( .start_time ), true == .assi_exhaustive and ffms( .end_time ) - 1 or ffms( .start_time )
 					frameTime = math.floor( 0.5*( msff( frame ) + msff( frame + 1 ) ) )
 					unless seenTimes[frameTime]
 						table.insert( times, frameTime )
 						seenTimes[frameTime] = true
-			else
-				unless seenTimes[.start_time]
-					table.insert( times, frameTime )
-					seenTimes[.start_time] = true
 
 	-- This will only happen if all lines are displayed for 0 frames.
 	unless 0 < #times


### PR DESCRIPTION
The frameTime was only ever being set in exhaustive mode, otherwise it's nil and the start time never gets added to the times table. Fixed by getting rid of the conditional block and limiting the loop instead (also gets rid of some duplication)
